### PR TITLE
srand should take an unsigned integer

### DIFF
--- a/srand.cc
+++ b/srand.cc
@@ -23,7 +23,7 @@ static Handle<Value> SRand (const Arguments& args) {
   if (args.Length() == 0) {
     return ThrowException(Exception::Error(String::New("Usage: srand(n)")));
   }
-  srand(args[0]->Int32Value());
+  srand(args[0]->Uint32Value());
   return Undefined();
 }
 


### PR DESCRIPTION
Changed `args[0]->Int32Value()` to `args[0]->Uint32Value()`

[srand specification](http://www.cplusplus.com/reference/cstdlib/srand/) gives following declaration: `void srand (unsigned int seed);`
