### PR TITLE
Use nan to abstract node versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .lock-wscript
 build/
+
+node_modules/
+.node-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+node_js:
+  - "0.11"
+  - "0.12"
+  - "5.0"
+script:
+  # TODO: Add simple spec test and remove the dummy tests.
+  - node -e 'console.log(require("./index.js").rand())'
+  - node -e 'console.log(require("./index.js").random())'
+  - node -e 'console.log(require("./index.js").srand(10))'
+  - node -e 'console.log(require("./index.js").seed(10))'
+  - node -e 'console.log(require("./index.js").RAND_MAX)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ node_js:
   - "0.11"
   - "0.12"
   - "5.0"
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 script:
   # TODO: Add simple spec test and remove the dummy tests.
   - node -e 'console.log(require("./index.js").rand())'

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,6 +2,7 @@
   'targets': [
     {
       'target_name': 'srand',
+      'include_dirs': [ "<!(node -e \"require('nan')\")" ],
       'sources': [ 'srand.cc' ]
     }
   ]

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
     "type": "git",
     "url": "http://github.com/isaacs/node-srand.git"
   },
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "nan": "^1.7.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   },
   "license": "ISC",
   "dependencies": {
-    "nan": "^1.7.0"
+    "nan": "^2.2.0"
   }
 }

--- a/srand.cc
+++ b/srand.cc
@@ -1,34 +1,34 @@
 
 #include <stdlib.h>
 #include <v8.h>
+#include <nan.h>
 #include <node.h>
 
 using namespace node;
 using namespace v8;
 
-static Handle<Value> Random (const Arguments&);
-static Handle<Value> Rand (const Arguments&);
-static Handle<Value> SRand (const Arguments&);
 extern "C" void init (Handle<Object>);
 
-static Handle<Value> Random (const Arguments& args) {
-  return Number::New(rand()/((double)RAND_MAX + 1));
+NAN_METHOD(Random) {
+  NanScope();
+  NanReturnValue(NanNew<Number>(rand()/((double)RAND_MAX + 1)));
 }
 
-static Handle<Value> Rand (const Arguments& args) {
-  return Integer::New(rand());
+NAN_METHOD(Rand) {
+  NanScope();
+  NanReturnValue(NanNew<Integer>(rand()));
 }
 
-static Handle<Value> SRand (const Arguments& args) {
+NAN_METHOD(SRand) {
+  NanScope();
   if (args.Length() == 0) {
-    return ThrowException(Exception::Error(String::New("Usage: srand(n)")));
+    NanThrowError(Exception::Error(NanNew<String>("Usage: srand(n)")));
   }
   srand(args[0]->Uint32Value());
-  return Undefined();
+  NanReturnValue(NanUndefined());
 }
 
 extern "C" void init (Handle<Object> target) {
-  HandleScope scope;
   NODE_SET_METHOD(target, "random", Random);
   NODE_SET_METHOD(target, "rand", Rand);
   NODE_SET_METHOD(target, "srand", SRand);

--- a/srand.cc
+++ b/srand.cc
@@ -3,6 +3,7 @@
 #include <v8.h>
 #include <nan.h>
 #include <node.h>
+#include <cstdlib>
 
 using namespace node;
 using namespace v8;

--- a/srand.cc
+++ b/srand.cc
@@ -1,40 +1,32 @@
-
 #include <stdlib.h>
-#include <v8.h>
 #include <nan.h>
 #include <node.h>
 #include <cstdlib>
 
-using namespace node;
-using namespace v8;
-
-extern "C" void init (Handle<Object>);
-
-NAN_METHOD(Random) {
-  NanScope();
-  NanReturnValue(NanNew<Number>(rand()/((double)RAND_MAX + 1)));
+void Random(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  v8::Local<v8::Number> num = Nan::New(rand()/((double)RAND_MAX + 1));
+  info.GetReturnValue().Set(num);
 }
 
-NAN_METHOD(Rand) {
-  NanScope();
-  NanReturnValue(NanNew<Integer>(rand()));
+void Rand(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  v8::Local<v8::Integer> num = Nan::New(rand());
+  info.GetReturnValue().Set(num);
 }
 
-NAN_METHOD(SRand) {
-  NanScope();
-  if (args.Length() == 0) {
-    NanThrowError(Exception::Error(NanNew<String>("Usage: srand(n)")));
+void SRand(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  if (info.Length() == 0) {
+    Nan::ThrowError("Usage: srand(n)");
   }
-  srand(args[0]->Uint32Value());
-  NanReturnValue(NanUndefined());
+  srand(info[0]->Uint32Value());
+  info.GetReturnValue().SetUndefined();
 }
 
-extern "C" void init (Handle<Object> target) {
-  NODE_SET_METHOD(target, "random", Random);
-  NODE_SET_METHOD(target, "rand", Rand);
-  NODE_SET_METHOD(target, "srand", SRand);
-  NODE_SET_METHOD(target, "seed", SRand);
-  NODE_DEFINE_CONSTANT(target, RAND_MAX);
+void Init(v8::Local<v8::Object> exports) {
+  exports->Set(Nan::New("random").ToLocalChecked(), Nan::New<v8::FunctionTemplate>(Random)->GetFunction());
+  exports->Set(Nan::New("rand").ToLocalChecked(), Nan::New<v8::FunctionTemplate>(Rand)->GetFunction());
+  exports->Set(Nan::New("srand").ToLocalChecked(), Nan::New<v8::FunctionTemplate>(SRand)->GetFunction());
+  exports->Set(Nan::New("seed").ToLocalChecked(), Nan::New<v8::FunctionTemplate>(SRand)->GetFunction());
+  exports->Set(Nan::New("RAND_MAX").ToLocalChecked(), Nan::New<v8::Integer>(RAND_MAX));
 }
 
-NODE_MODULE(srand, init)
+NODE_MODULE(srand, Init)


### PR DESCRIPTION
To support node v0.12.x which breaks the compatibility, we can use [nan](https://github.com/rvagg/nan).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/isaacs/node-srand/6)

<!-- Reviewable:end -->
